### PR TITLE
Redact credentials from logs

### DIFF
--- a/src/dio_chacon_wifi_api/session.py
+++ b/src/dio_chacon_wifi_api/session.py
@@ -20,6 +20,14 @@ STATE_STOPPED = "stopped"
 
 _LOGGER = logging.getLogger(__name__)
 
+_SENSITIVE_QUERY_KEYS = ("email", "password", "sessionToken")
+
+
+def _redact_url(url) -> str:
+    """Returns the URL as a string with sensitive query parameters masked."""
+    redactions = {key: "***" for key in _SENSITIVE_QUERY_KEYS if key in url.query}
+    return str(url.update_query(redactions))
+
 
 class DIOChaconClientSession:
     """HTTP session manager for DIO Chacon API.
@@ -51,16 +59,16 @@ class DIOChaconClientSession:
         self._callback = callback
 
         async def on_request_start(session, trace_config_ctx, params):
-            _LOGGER.debug(f"aiohttp request start : {params}")
+            _LOGGER.debug("aiohttp request start : %s %s", params.method, _redact_url(params.url))
 
         async def on_request_chunk_sent(session, trace_config_ctx, params):
-            _LOGGER.debug(f"aiohttp request chunk sent : {params}")
+            _LOGGER.debug("aiohttp request chunk sent : %s %s", params.method, _redact_url(params.url))
 
         async def on_response_chunk_received(session, trace_config_ctx, params):
-            _LOGGER.debug(f"aiohttp response chunk received : {params}")
+            _LOGGER.debug("aiohttp response chunk received : %s %s", params.method, _redact_url(params.url))
 
         async def on_request_end(session, trace_config_ctx, params):
-            _LOGGER.debug(f"aiohttp request end : {params}")
+            _LOGGER.debug("aiohttp request end : %s %s", params.method, _redact_url(params.url))
 
         trace_config = aiohttp.TraceConfig()
         trace_config.on_request_start.append(on_request_start)
@@ -125,7 +133,7 @@ class DIOChaconClientSession:
                         self._callback(msg)
 
         except aiohttp.ClientResponseError as error:
-            _LOGGER.error("Unexpected response received from server : %s", error)
+            _LOGGER.error("Unexpected response received from server : %s %s", error.status, error.message)
             self._state = STATE_STOPPED
         except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as error:
             if self._failed_attempts >= MAX_FAILED_ATTEMPTS:

--- a/src/dio_chacon_wifi_api/session.py
+++ b/src/dio_chacon_wifi_api/session.py
@@ -10,6 +10,8 @@ import urllib
 
 import aiohttp
 
+from .utils import redact_url
+
 
 MAX_FAILED_ATTEMPTS = 5
 
@@ -19,14 +21,6 @@ STATE_STARTING = "starting"
 STATE_STOPPED = "stopped"
 
 _LOGGER = logging.getLogger(__name__)
-
-_SENSITIVE_QUERY_KEYS = ("email", "password", "sessionToken")
-
-
-def _redact_url(url) -> str:
-    """Returns the URL as a string with sensitive query parameters masked."""
-    redactions = {key: "***" for key in _SENSITIVE_QUERY_KEYS if key in url.query}
-    return str(url.update_query(redactions))
 
 
 class DIOChaconClientSession:
@@ -59,16 +53,16 @@ class DIOChaconClientSession:
         self._callback = callback
 
         async def on_request_start(session, trace_config_ctx, params):
-            _LOGGER.debug("aiohttp request start : %s %s", params.method, _redact_url(params.url))
+            _LOGGER.debug("aiohttp request start : %s %s", params.method, redact_url(params.url))
 
         async def on_request_chunk_sent(session, trace_config_ctx, params):
-            _LOGGER.debug("aiohttp request chunk sent : %s %s", params.method, _redact_url(params.url))
+            _LOGGER.debug("aiohttp request chunk sent : %s %s", params.method, redact_url(params.url))
 
         async def on_response_chunk_received(session, trace_config_ctx, params):
-            _LOGGER.debug("aiohttp response chunk received : %s %s", params.method, _redact_url(params.url))
+            _LOGGER.debug("aiohttp response chunk received : %s %s", params.method, redact_url(params.url))
 
         async def on_request_end(session, trace_config_ctx, params):
-            _LOGGER.debug("aiohttp request end : %s %s", params.method, _redact_url(params.url))
+            _LOGGER.debug("aiohttp request end : %s %s", params.method, redact_url(params.url))
 
         trace_config = aiohttp.TraceConfig()
         trace_config.on_request_start.append(on_request_start)

--- a/src/dio_chacon_wifi_api/utils.py
+++ b/src/dio_chacon_wifi_api/utils.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""Utility helpers shared across the DIO Chacon wifi API modules."""
+from yarl import URL
+
+
+SENSITIVE_QUERY_KEYS = ("email", "password", "sessionToken")
+
+
+def redact_url(url: URL) -> str:
+    """Returns the URL as a string with sensitive query parameters masked."""
+    redactions = {key: "***" for key in SENSITIVE_QUERY_KEYS if key in url.query}
+    return str(url.update_query(redactions))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,8 +8,6 @@ import pytest
 from aiohttp_fake_server_utils import MOCK_PORT
 from aiohttp_fake_server_utils import run_fake_http_server
 from dio_chacon_wifi_api.session import DIOChaconClientSession
-from dio_chacon_wifi_api.session import _redact_url
-from yarl import URL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,18 +43,3 @@ async def test_session(aiohttp_server) -> None:
     message_queue.task_done()
 
     await session.disconnect()
-
-
-def test_redact_url_masks_credentials() -> None:
-    """The redacted URL masks the credentials and keeps the non sensitive service name visible."""
-
-    url = URL("wss://host/ws?email=toto@toto.com&password=DUMMY_PASS&serviceName=test_client&sessionToken=r:abc123")
-    redacted = _redact_url(url)
-
-    assert "toto@toto.com" not in redacted
-    assert "DUMMY_PASS" not in redacted
-    assert "r:abc123" not in redacted
-    assert "email=***" in redacted
-    assert "password=***" in redacted
-    assert "sessionToken=***" in redacted
-    assert "serviceName=test_client" in redacted

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,6 +8,8 @@ import pytest
 from aiohttp_fake_server_utils import MOCK_PORT
 from aiohttp_fake_server_utils import run_fake_http_server
 from dio_chacon_wifi_api.session import DIOChaconClientSession
+from dio_chacon_wifi_api.session import _redact_url
+from yarl import URL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,3 +45,18 @@ async def test_session(aiohttp_server) -> None:
     message_queue.task_done()
 
     await session.disconnect()
+
+
+def test_redact_url_masks_credentials() -> None:
+    """The redacted URL masks the credentials and keeps the non sensitive service name visible."""
+
+    url = URL("wss://host/ws?email=toto@toto.com&password=DUMMY_PASS&serviceName=test_client&sessionToken=r:abc123")
+    redacted = _redact_url(url)
+
+    assert "toto@toto.com" not in redacted
+    assert "DUMMY_PASS" not in redacted
+    assert "r:abc123" not in redacted
+    assert "email=***" in redacted
+    assert "password=***" in redacted
+    assert "sessionToken=***" in redacted
+    assert "serviceName=test_client" in redacted

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+# coding: utf-8
+"""Tests utils.py shared helpers."""
+from dio_chacon_wifi_api.utils import redact_url
+from yarl import URL
+
+
+def test_redact_url_masks_credentials() -> None:
+    """The redacted URL masks the credentials and keeps the non sensitive service name visible."""
+
+    url = URL("wss://host/ws?email=toto@toto.com&password=DUMMY_PASS&serviceName=test_client&sessionToken=r:abc123")
+    redacted = redact_url(url)
+
+    assert "toto@toto.com" not in redacted
+    assert "DUMMY_PASS" not in redacted
+    assert "r:abc123" not in redacted
+    assert "email=***" in redacted
+    assert "password=***" in redacted
+    assert "sessionToken=***" in redacted
+    assert "serviceName=test_client" in redacted
+
+
+def test_redact_url_without_sensitive_query_returns_url_unchanged() -> None:
+    """A URL without any sensitive query parameter is returned unchanged."""
+
+    url = URL("https://host/api?serviceName=test_client&page=1")
+    redacted = redact_url(url)
+
+    assert redacted == "https://host/api?serviceName=test_client&page=1"
+
+
+def test_redact_url_without_query_returns_url_unchanged() -> None:
+    """A URL without any query parameter is returned unchanged."""
+
+    url = URL("https://host/api")
+    redacted = redact_url(url)
+
+    assert redacted == "https://host/api"
+
+
+def test_redact_url_masks_only_present_sensitive_keys() -> None:
+    """Only the sensitive keys that are present in the URL are masked."""
+
+    url = URL("wss://host/ws?email=toto@toto.com&serviceName=test_client")
+    redacted = redact_url(url)
+
+    assert "toto@toto.com" not in redacted
+    assert "email=***" in redacted
+    assert "password" not in redacted
+    assert "sessionToken" not in redacted
+    assert "serviceName=test_client" in redacted


### PR DESCRIPTION
The WebSocket connection URL carries the email and password as query parameters. Two log paths exposed the plaintext password: the aiohttp trace callbacks logged the full request parameters at DEBUG level, and the error handler logged the raw ClientResponseError whose string form includes the request URL.

The trace callbacks now log only the request method and a URL whose credential query parameters (email, password, session token) are masked, and the error handler logs only the response status and message.