### PR TITLE
Add API specifications for the cloud protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Chacon have lots of devices that could be managed via this library.
 The wifi protocol is described in [Protocol.md](https://github.com/cnico/dio-chacon-wifi-api/blob/main/Protocol.md).
 You can test this protocol manually through postman with establishing a connection via correct authentification (email + password of your chacon mobile app account) ; then upgrade the connection to Websocket and then interact with json messages in the Websocket stream.
 
+The same protocol is also described in two machine-readable specifications under the [docs/](https://github.com/cnico/dio-chacon-wifi-api/blob/main/docs) folder :
+
+- [docs/asyncapi.yaml](https://github.com/cnico/dio-chacon-wifi-api/blob/main/docs/asyncapi.yaml) is an [AsyncAPI 3.0](https://www.asyncapi.com/) description of the WebSocket protocol (requests, replies and server-pushed device state events). Open it in the [AsyncAPI Studio](https://studio.asyncapi.com/) to browse the operations and message schemas, or generate static HTML documentation locally with the [`@asyncapi/cli`](https://www.asyncapi.com/tools/cli) : `asyncapi generate fromTemplate docs/asyncapi.yaml @asyncapi/html-template -o ./asyncapi-html`. AsyncAPI Studio is a hosted service, so prefer the local CLI command if you modify the spec to include real device identifiers or session tokens.
+- [docs/opencollection.yml](https://github.com/cnico/dio-chacon-wifi-api/blob/main/docs/opencollection.yml) is an [OpenCollection 1.0](https://www.opencollection.io/) executable collection bundling the REST login call and the WebSocket operations. Import it in an OpenCollection-aware client — [Bruno](https://www.usebruno.com/) is the primary tested target — and fill in the `email` / `password` collection variables with your Chacon mobile app account to replay the requests against the cloud server. The credentials travel in the URL query string, so treat any exported version of the collection as sensitive.
+
 For the implementation of the library, it is based on the great [aiohttp](https://docs.aiohttp.org/) library that we use as a http client for REST requests and websocket exchange.
 All the library is asynchronous and based on [asyncio](https://docs.python.org/3/library/asyncio-dev.html).
 

--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -1,0 +1,500 @@
+asyncapi: 3.0.0
+
+info:
+  title: DIO Chacon WiFi API
+  version: "1.0.0"
+  description: |
+    WebSocket protocol of Chacon's cloud service to connect and control DIO devices:
+    shutters and light/plug switches.
+
+    The client opens a single WebSocket connection (after a REST login or directly with
+    credentials). Every exchange is a JSON envelope:
+
+    - Request sent by the client: `{"method": "...", "path": "...", "parameters": {}, "id": N}`.
+      The `id` is incremented per request and echoed in the matching response.
+    - Response sent by the server: `{"id": N, "status": 200, "data": ...}`.
+    - The server also pushes unsolicited `deviceState` / `update` events when a
+      device state changes.
+
+servers:
+  production:
+    host: l4hfront-prod.chacon.cloud
+    pathname: /ws
+    protocol: wss
+    description: |
+      Production WebSocket endpoint. Authenticate either with a session token obtained
+      from the REST login (`/ws?sessionToken=r:...`) or directly with credentials
+      (`/ws?email=...&password=...&serviceName=...`).
+
+channels:
+  ws:
+    address: /ws
+    description: The single WebSocket connection carrying every request, response and event.
+    messages:
+      connectionStatus:
+        $ref: '#/components/messages/ConnectionStatus'
+      getUserRequest:
+        $ref: '#/components/messages/GetUserRequest'
+      getUserResponse:
+        $ref: '#/components/messages/GetUserResponse'
+      getDevicesRequest:
+        $ref: '#/components/messages/GetDevicesRequest'
+      getDevicesResponse:
+        $ref: '#/components/messages/GetDevicesResponse'
+      getDeviceStatesRequest:
+        $ref: '#/components/messages/GetDeviceStatesRequest'
+      getDeviceStatesResponse:
+        $ref: '#/components/messages/GetDeviceStatesResponse'
+      shutterMoveRequest:
+        $ref: '#/components/messages/ShutterMoveRequest'
+      shutterPositionRequest:
+        $ref: '#/components/messages/ShutterPositionRequest'
+      switchRequest:
+        $ref: '#/components/messages/SwitchRequest'
+      logoutRequest:
+        $ref: '#/components/messages/LogoutRequest'
+      actionAck:
+        $ref: '#/components/messages/ActionAck'
+      deviceStateUpdate:
+        $ref: '#/components/messages/DeviceStateUpdate'
+
+operations:
+  onConnection:
+    action: send
+    channel:
+      $ref: '#/channels/ws'
+    summary: Connection result pushed by the server right after the socket opens.
+    messages:
+      - $ref: '#/channels/ws/messages/connectionStatus'
+
+  getUser:
+    action: receive
+    channel:
+      $ref: '#/channels/ws'
+    summary: Retrieve the current user info.
+    messages:
+      - $ref: '#/channels/ws/messages/getUserRequest'
+    reply:
+      channel:
+        $ref: '#/channels/ws'
+      messages:
+        - $ref: '#/channels/ws/messages/getUserResponse'
+
+  getDevices:
+    action: receive
+    channel:
+      $ref: '#/channels/ws'
+    summary: List all devices of the account.
+    messages:
+      - $ref: '#/channels/ws/messages/getDevicesRequest'
+    reply:
+      channel:
+        $ref: '#/channels/ws'
+      messages:
+        - $ref: '#/channels/ws/messages/getDevicesResponse'
+
+  getDeviceStates:
+    action: receive
+    channel:
+      $ref: '#/channels/ws'
+    summary: Retrieve the detailed state of the given devices.
+    messages:
+      - $ref: '#/channels/ws/messages/getDeviceStatesRequest'
+    reply:
+      channel:
+        $ref: '#/channels/ws'
+      messages:
+        - $ref: '#/channels/ws/messages/getDeviceStatesResponse'
+
+  moveShutter:
+    action: receive
+    channel:
+      $ref: '#/channels/ws'
+    summary: Move a shutter up, down or stop it.
+    messages:
+      - $ref: '#/channels/ws/messages/shutterMoveRequest'
+    reply:
+      channel:
+        $ref: '#/channels/ws'
+      messages:
+        - $ref: '#/channels/ws/messages/actionAck'
+
+  setShutterPosition:
+    action: receive
+    channel:
+      $ref: '#/channels/ws'
+    summary: Set a shutter to a given open level.
+    messages:
+      - $ref: '#/channels/ws/messages/shutterPositionRequest'
+    reply:
+      channel:
+        $ref: '#/channels/ws'
+      messages:
+        - $ref: '#/channels/ws/messages/actionAck'
+
+  switchDevice:
+    action: receive
+    channel:
+      $ref: '#/channels/ws'
+    summary: Switch a light or a plug on or off.
+    messages:
+      - $ref: '#/channels/ws/messages/switchRequest'
+    reply:
+      channel:
+        $ref: '#/channels/ws'
+      messages:
+        - $ref: '#/channels/ws/messages/actionAck'
+
+  logout:
+    action: receive
+    channel:
+      $ref: '#/channels/ws'
+    summary: Close the session.
+    messages:
+      - $ref: '#/channels/ws/messages/logoutRequest'
+    reply:
+      channel:
+        $ref: '#/channels/ws'
+      messages:
+        - $ref: '#/channels/ws/messages/actionAck'
+
+  onDeviceStateUpdate:
+    action: send
+    channel:
+      $ref: '#/channels/ws'
+    summary: |
+      Device state pushed by the server when a device changes: shutter movement
+      or switch toggled.
+    messages:
+      - $ref: '#/channels/ws/messages/deviceStateUpdate'
+
+components:
+  messages:
+    ConnectionStatus:
+      title: Connection status
+      summary: Pushed once after the socket opens.
+      payload:
+        type: object
+        properties:
+          name:
+            type: string
+            const: connection
+          action:
+            type: string
+            enum: [success, invalid]
+          data:
+            type: string
+      examples:
+        - name: success
+          payload:
+            name: connection
+            action: success
+            data: ""
+
+    GetUserRequest:
+      title: Get user request
+      payload:
+        $ref: '#/components/schemas/RequestEnvelope'
+      examples:
+        - name: getUser
+          payload:
+            method: GET
+            path: /user
+            parameters: {}
+            id: 1
+
+    GetUserResponse:
+      title: Get user response
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/ResponseEnvelope'
+          - type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/User'
+
+    GetDevicesRequest:
+      title: Get devices request
+      payload:
+        $ref: '#/components/schemas/RequestEnvelope'
+      examples:
+        - name: getDevices
+          payload:
+            method: GET
+            path: /device
+            parameters: {}
+            id: 1
+
+    GetDevicesResponse:
+      title: Get devices response
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/ResponseEnvelope'
+          - type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Device'
+
+    GetDeviceStatesRequest:
+      title: Get device states request
+      payload:
+        $ref: '#/components/schemas/RequestEnvelope'
+      examples:
+        - name: getDeviceStates
+          payload:
+            method: POST
+            path: /device/states
+            parameters:
+              devices: ["L4HActuator_..."]
+            id: 22
+
+    GetDeviceStatesResponse:
+      title: Get device states response
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/ResponseEnvelope'
+          - type: object
+            properties:
+              data:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/DeviceState'
+
+    ShutterMoveRequest:
+      title: Shutter move request
+      payload:
+        type: object
+        required: [method, path, parameters, id]
+        properties:
+          method:
+            type: string
+            const: POST
+          path:
+            type: string
+            description: "/device/{deviceId}/action/mvtlinear"
+          parameters:
+            type: object
+            properties:
+              movement:
+                type: string
+                enum: [up, down, stop]
+          id:
+            type: integer
+      examples:
+        - name: moveDown
+          payload:
+            method: POST
+            path: /device/L4HActuator_.../action/mvtlinear
+            parameters:
+              movement: down
+            id: 8
+
+    ShutterPositionRequest:
+      title: Shutter position request
+      payload:
+        type: object
+        required: [method, path, parameters, id]
+        properties:
+          method:
+            type: string
+            const: POST
+          path:
+            type: string
+            description: "/device/{deviceId}/action/openlevel"
+          parameters:
+            type: object
+            properties:
+              openLevel:
+                type: integer
+                minimum: 0
+                maximum: 100
+          id:
+            type: integer
+      examples:
+        - name: setPosition
+          payload:
+            method: POST
+            path: /device/L4HActuator_.../action/openlevel
+            parameters:
+              openLevel: 75
+            id: 24
+
+    SwitchRequest:
+      title: Switch request
+      payload:
+        type: object
+        required: [method, path, parameters, id]
+        properties:
+          method:
+            type: string
+            const: POST
+          path:
+            type: string
+            description: "/device/{deviceId}/action/switch"
+          parameters:
+            type: object
+            properties:
+              value:
+                type: integer
+                enum: [0, 1]
+                description: 0 = off, 1 = on
+          id:
+            type: integer
+      examples:
+        - name: switchOn
+          payload:
+            method: POST
+            path: /device/L4HActuator_.../action/switch
+            parameters:
+              value: 1
+            id: 12
+
+    LogoutRequest:
+      title: Logout request
+      payload:
+        $ref: '#/components/schemas/RequestEnvelope'
+      examples:
+        - name: logout
+          payload:
+            method: POST
+            path: /session/logout
+            parameters: {}
+            id: 13
+
+    ActionAck:
+      title: Action acknowledgement
+      summary: Immediate acknowledgement of an action. The effective state follows via a deviceState update.
+      payload:
+        type: object
+        properties:
+          id:
+            type: integer
+          status:
+            type: integer
+
+    DeviceStateUpdate:
+      title: Device state update
+      summary: Unsolicited device state pushed by the server.
+      payload:
+        type: object
+        properties:
+          name:
+            type: string
+            const: deviceState
+          action:
+            type: string
+            const: update
+          data:
+            $ref: '#/components/schemas/DeviceState'
+      examples:
+        - name: shutterMoved
+          payload:
+            name: deviceState
+            action: update
+            data:
+              di: L4HActuator_...
+              rc: 1
+              links:
+                - rt: oic.r.openlevel
+                  openLevel: 69
+                - rt: oic.r.movement.linear
+                  movement: down
+
+  schemas:
+    RequestEnvelope:
+      type: object
+      required: [method, path, parameters, id]
+      description: Common envelope of every client request.
+      properties:
+        method:
+          type: string
+          enum: [GET, POST]
+        path:
+          type: string
+        parameters:
+          type: object
+        id:
+          type: integer
+          description: Incremented per request, echoed in the matching response.
+
+    ResponseEnvelope:
+      type: object
+      description: Common envelope of every server response.
+      properties:
+        id:
+          type: integer
+        status:
+          type: integer
+          examples: [200]
+        data: {}
+
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        bleKey:
+          type: string
+
+    Device:
+      type: object
+      properties:
+        id:
+          type: string
+        provider:
+          type: string
+          description: L4HActuator for DIO actuators.
+        name:
+          type: string
+        modelName:
+          type: string
+        vendor:
+          type: string
+        softwareVersion:
+          type: string
+        type:
+          type: string
+          description: |
+            Device type. Known values: `.dio1.wifi.shutter.mvt_linear.`,
+            `.dio1.wifi.genericSwitch.switch.`, `.dio1.wifi.plug.switch.`.
+        roomId:
+          type: string
+        image:
+          type: [string, "null"]
+
+    Link:
+      type: object
+      description: |
+        A device resource. `rt` is the resource type, `href` its name. Other fields
+        depend on `rt`: `openLevel`, `movement` or `value`.
+      properties:
+        rt:
+          type: string
+        href:
+          type: string
+      additionalProperties: true
+
+    DeviceState:
+      type: object
+      properties:
+        rt:
+          type: string
+          description: e.g. `oic.d.blind` or `oic.d.switch`.
+        di:
+          type: string
+        provider:
+          type: string
+        rc:
+          type: integer
+          description: 1 = connected, 0 = disconnected.
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'

--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -7,14 +7,27 @@ info:
     WebSocket protocol of Chacon's cloud service to connect and control DIO devices:
     shutters and light/plug switches.
 
-    The client opens a single WebSocket connection (after a REST login or directly with
-    credentials). Every exchange is a JSON envelope:
+    Operations are described from the server's perspective: `receive` operations
+    are client requests handled by the server, `send` operations are unsolicited
+    messages pushed by the server.
+
+    The client opens a single WebSocket connection (after a REST login or directly
+    with credentials). Every exchange is a JSON envelope:
 
     - Request sent by the client: `{"method": "...", "path": "...", "parameters": {}, "id": N}`.
       The `id` is incremented per request and echoed in the matching response.
     - Response sent by the server: `{"id": N, "status": 200, "data": ...}`.
     - The server also pushes unsolicited `deviceState` / `update` events when a
       device state changes.
+
+    Security considerations:
+
+    - Prefer the `sessionToken` flow over the `email` + `password` query parameters.
+      When credentials travel in the URL, they end up in proxy access logs, server
+      access logs and any client-side trace tooling, so they must be redacted
+      before being persisted.
+    - Only `wss` to `*.chacon.cloud` is supported; plaintext `ws` must not be used
+      because credentials and session tokens travel in the URL.
 
 servers:
   production:
@@ -25,10 +38,35 @@ servers:
       Production WebSocket endpoint. Authenticate either with a session token obtained
       from the REST login (`/ws?sessionToken=r:...`) or directly with credentials
       (`/ws?email=...&password=...&serviceName=...`).
+    bindings:
+      ws:
+        query:
+          type: object
+          oneOf:
+            - required: [sessionToken]
+            - required: [email, password, serviceName]
+          properties:
+            sessionToken:
+              type: string
+              description: Session token returned by the REST login. SENSITIVE.
+            email:
+              type: string
+              format: email
+              description: Account email. PII, also acts as the login identifier.
+            password:
+              type: string
+              format: password
+              description: Account password. SENSITIVE — transmitted in the URL.
+            serviceName:
+              type: string
+              description: Arbitrary client identifier.
+    security:
+      - $ref: '#/components/securitySchemes/sessionTokenQuery'
+      - $ref: '#/components/securitySchemes/userPasswordQuery'
 
 channels:
   ws:
-    address: /ws
+    address: /
     description: The single WebSocket connection carrying every request, response and event.
     messages:
       connectionStatus:
@@ -193,6 +231,8 @@ components:
 
     GetUserRequest:
       title: Get user request
+      correlationId:
+        location: $message.payload#/id
       payload:
         $ref: '#/components/schemas/RequestEnvelope'
       examples:
@@ -205,6 +245,8 @@ components:
 
     GetUserResponse:
       title: Get user response
+      correlationId:
+        location: $message.payload#/id
       payload:
         allOf:
           - $ref: '#/components/schemas/ResponseEnvelope'
@@ -215,6 +257,8 @@ components:
 
     GetDevicesRequest:
       title: Get devices request
+      correlationId:
+        location: $message.payload#/id
       payload:
         $ref: '#/components/schemas/RequestEnvelope'
       examples:
@@ -223,10 +267,12 @@ components:
             method: GET
             path: /device
             parameters: {}
-            id: 1
+            id: 2
 
     GetDevicesResponse:
       title: Get devices response
+      correlationId:
+        location: $message.payload#/id
       payload:
         allOf:
           - $ref: '#/components/schemas/ResponseEnvelope'
@@ -239,6 +285,8 @@ components:
 
     GetDeviceStatesRequest:
       title: Get device states request
+      correlationId:
+        location: $message.payload#/id
       payload:
         $ref: '#/components/schemas/RequestEnvelope'
       examples:
@@ -247,11 +295,13 @@ components:
             method: POST
             path: /device/states
             parameters:
-              devices: ["L4HActuator_..."]
-            id: 22
+              devices: ["L4HActuator_abcdef1234567890"]
+            id: 3
 
     GetDeviceStatesResponse:
       title: Get device states response
+      correlationId:
+        location: $message.payload#/id
       payload:
         allOf:
           - $ref: '#/components/schemas/ResponseEnvelope'
@@ -264,95 +314,95 @@ components:
 
     ShutterMoveRequest:
       title: Shutter move request
+      correlationId:
+        location: $message.payload#/id
       payload:
-        type: object
-        required: [method, path, parameters, id]
-        properties:
-          method:
-            type: string
-            const: POST
-          path:
-            type: string
-            description: "/device/{deviceId}/action/mvtlinear"
-          parameters:
-            type: object
+        allOf:
+          - $ref: '#/components/schemas/RequestEnvelope'
+          - type: object
             properties:
-              movement:
-                type: string
-                enum: [up, down, stop]
-          id:
-            type: integer
+              path:
+                description: "/device/{deviceId}/action/mvtlinear"
+              parameters:
+                type: object
+                required: [movement]
+                properties:
+                  movement:
+                    type: string
+                    enum: [up, down, stop]
       examples:
         - name: moveDown
           payload:
             method: POST
-            path: /device/L4HActuator_.../action/mvtlinear
+            path: /device/L4HActuator_abcdef1234567890/action/mvtlinear
             parameters:
               movement: down
-            id: 8
+            id: 4
 
     ShutterPositionRequest:
       title: Shutter position request
+      correlationId:
+        location: $message.payload#/id
       payload:
-        type: object
-        required: [method, path, parameters, id]
-        properties:
-          method:
-            type: string
-            const: POST
-          path:
-            type: string
-            description: "/device/{deviceId}/action/openlevel"
-          parameters:
-            type: object
+        allOf:
+          - $ref: '#/components/schemas/RequestEnvelope'
+          - type: object
             properties:
-              openLevel:
-                type: integer
-                minimum: 0
-                maximum: 100
-          id:
-            type: integer
+              path:
+                description: "/device/{deviceId}/action/openlevel"
+              parameters:
+                type: object
+                required: [openLevel]
+                properties:
+                  openLevel:
+                    type: integer
+                    minimum: 0
+                    maximum: 100
       examples:
         - name: setPosition
           payload:
             method: POST
-            path: /device/L4HActuator_.../action/openlevel
+            path: /device/L4HActuator_abcdef1234567890/action/openlevel
             parameters:
               openLevel: 75
-            id: 24
+            id: 5
 
     SwitchRequest:
       title: Switch request
+      correlationId:
+        location: $message.payload#/id
       payload:
-        type: object
-        required: [method, path, parameters, id]
-        properties:
-          method:
-            type: string
-            const: POST
-          path:
-            type: string
-            description: "/device/{deviceId}/action/switch"
-          parameters:
-            type: object
+        allOf:
+          - $ref: '#/components/schemas/RequestEnvelope'
+          - type: object
             properties:
-              value:
-                type: integer
-                enum: [0, 1]
-                description: 0 = off, 1 = on
-          id:
-            type: integer
+              path:
+                description: "/device/{deviceId}/action/switch"
+              parameters:
+                type: object
+                required: [value]
+                properties:
+                  value:
+                    type: integer
+                    enum: [0, 1]
+                    description: 0 = off, 1 = on
       examples:
         - name: switchOn
           payload:
             method: POST
-            path: /device/L4HActuator_.../action/switch
+            path: /device/L4HActuator_abcdef1234567890/action/switch
             parameters:
               value: 1
-            id: 12
+            id: 6
 
     LogoutRequest:
       title: Logout request
+      summary: |
+        Closes the session. Only required when the client authenticated via the
+        REST login and the `sessionToken` query parameter. Clients connected with
+        the `email` + `password` query parameters simply close the WebSocket.
+      correlationId:
+        location: $message.payload#/id
       payload:
         $ref: '#/components/schemas/RequestEnvelope'
       examples:
@@ -361,18 +411,15 @@ components:
             method: POST
             path: /session/logout
             parameters: {}
-            id: 13
+            id: 7
 
     ActionAck:
       title: Action acknowledgement
       summary: Immediate acknowledgement of an action. The effective state follows via a deviceState update.
+      correlationId:
+        location: $message.payload#/id
       payload:
-        type: object
-        properties:
-          id:
-            type: integer
-          status:
-            type: integer
+        $ref: '#/components/schemas/ResponseEnvelope'
 
     DeviceStateUpdate:
       title: Device state update
@@ -394,13 +441,29 @@ components:
             name: deviceState
             action: update
             data:
-              di: L4HActuator_...
+              di: L4HActuator_abcdef1234567890
               rc: 1
               links:
                 - rt: oic.r.openlevel
                   openLevel: 69
                 - rt: oic.r.movement.linear
                   movement: down
+
+  securitySchemes:
+    sessionTokenQuery:
+      type: httpApiKey
+      in: query
+      name: sessionToken
+      description: |
+        Bearer token obtained from the REST login endpoint. Passed as a query
+        parameter on the WebSocket URL. SENSITIVE — must be redacted from logs.
+    userPasswordQuery:
+      type: userPassword
+      description: |
+        Email and password passed as `email` and `password` query parameters on
+        the WebSocket URL. SENSITIVE and not recommended: prefer the
+        `sessionTokenQuery` flow because URL-embedded credentials end up in
+        proxy logs and client trace tooling.
 
   schemas:
     RequestEnvelope:
@@ -417,17 +480,21 @@ components:
           type: object
         id:
           type: integer
+          minimum: 1
           description: Incremented per request, echoed in the matching response.
 
     ResponseEnvelope:
       type: object
       description: Common envelope of every server response.
+      required: [id, status]
       properties:
         id:
           type: integer
+          minimum: 1
         status:
           type: integer
-          examples: [200]
+          description: 200 on success; any other value means the client raises an error.
+          default: 200
         data: {}
 
     User:
@@ -462,8 +529,12 @@ components:
         type:
           type: string
           description: |
-            Device type. Known values: `.dio1.wifi.shutter.mvt_linear.`,
-            `.dio1.wifi.genericSwitch.switch.`, `.dio1.wifi.plug.switch.`.
+            Device type. The Python library matches on the substrings
+            `.wifi.shutter.`, `.wifi.genericSwitch.` and `.wifi.plug.`.
+          enum:
+            - .dio1.wifi.shutter.mvt_linear.
+            - .dio1.wifi.genericSwitch.switch.
+            - .dio1.wifi.plug.switch.
         roomId:
           type: string
         image:

--- a/docs/opencollection.yml
+++ b/docs/opencollection.yml
@@ -4,6 +4,20 @@ info:
   name: DIO Chacon WiFi API
   summary: Connect and control DIO devices (shutters and switches).
   version: "1.0.0"
+  description: |
+    Executable collection for the Chacon cloud WebSocket protocol.
+
+    Security considerations:
+
+    - The WebSocket carries credentials in the URL query string. Exporting,
+      sharing or screen-recording this collection (or any request inspector
+      that logged it) will leak `email`, `password` or `sessionToken`.
+    - Treat the `email`, `password` and `sessionToken` variables as secrets
+      even when only `password` is masked by your tooling — the rendered URL
+      contains all of them in plaintext.
+    - Prefer the REST `Login` followed by the `Connection (token)` request
+      over the `Connection (credentials)` variant when integrating with a
+      shared environment.
 
 config:
   environments:
@@ -13,11 +27,15 @@ config:
           value: https://l4hfront-prod.chacon.cloud
         - name: wsUrl
           value: wss://l4hfront-prod.chacon.cloud/ws
+        - name: serviceName
+          value: opencollection
         - name: email
           value: ""
+          secret: true
+        - name: password
+          secret: true
         - name: sessionToken
           value: ""
-        - name: password
           secret: true
 
 bundled: true
@@ -47,9 +65,12 @@ items:
                 "installationId": "top"
               }
         docs: |-
-          HTTP login. The response contains a session token used to open the
-          WebSocket connection. Copy the returned `sessionToken` into the
-          environment variable `sessionToken`.
+          Optional REST login: only useful when authenticating the WebSocket via
+          a `sessionToken`. The Python library does not call this endpoint — it
+          opens the WebSocket directly with credentials in the query string.
+
+          The response contains a session token. Copy the returned `sessionToken`
+          into the environment variable `sessionToken`.
 
   - info:
       name: WebSocket
@@ -61,19 +82,26 @@ items:
           type: websocket
           seq: 1
         websocket:
-          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          url:
+            - title: With credentials (default — used by the Python library)
+              selected: true
+              value: "{{wsUrl}}?email={{email}}&password={{password}}&serviceName={{serviceName}}"
+            - title: With session token (after REST Login)
+              value: "{{wsUrl}}?sessionToken={{sessionToken}}"
         docs: |-
-          Opens the WebSocket connection. Authenticate with a session token from
-          the REST Login, or directly with credentials:
-          `{{wsUrl}}?email={{email}}&password={{password}}&serviceName=opencollection`.
-          On success the server sends `{"name":"connection","action":"success"}`.
+          Opens the WebSocket connection. The default URL uses the
+          credentials-in-query flow, which matches what the Python library does.
+          The alternative URL uses the `sessionToken` obtained from the REST
+          Login request — preferred when the connection URL might be exported or
+          logged. On success the server pushes
+          `{"name":"connection","action":"success","data":""}`.
 
       - info:
           name: Get user
           type: websocket
           seq: 2
         websocket:
-          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          url: "{{wsUrl}}?email={{email}}&password={{password}}&serviceName={{serviceName}}"
           message:
             type: json
             data: '{"method":"GET","path":"/user","parameters":{},"id":1}'
@@ -84,10 +112,10 @@ items:
           type: websocket
           seq: 3
         websocket:
-          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          url: "{{wsUrl}}?email={{email}}&password={{password}}&serviceName={{serviceName}}"
           message:
             type: json
-            data: '{"method":"GET","path":"/device","parameters":{},"id":1}'
+            data: '{"method":"GET","path":"/device","parameters":{},"id":2}'
         docs: Lists all the devices of the account.
 
       - info:
@@ -95,10 +123,10 @@ items:
           type: websocket
           seq: 4
         websocket:
-          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          url: "{{wsUrl}}?email={{email}}&password={{password}}&serviceName={{serviceName}}"
           message:
             type: json
-            data: '{"method":"POST","path":"/device/states","parameters":{"devices":["L4HActuator_..."]},"id":22}'
+            data: '{"method":"POST","path":"/device/states","parameters":{"devices":["L4HActuator_abcdef1234567890"]},"id":3}'
         docs: Retrieves the state of the given devices.
 
       - info:
@@ -106,28 +134,33 @@ items:
           type: websocket
           seq: 5
         websocket:
-          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          url: "{{wsUrl}}?email={{email}}&password={{password}}&serviceName={{serviceName}}"
           message:
             - title: Move up / down / stop
               selected: true
               message:
                 type: json
-                data: '{"method":"POST","path":"/device/L4HActuator_.../action/mvtlinear","parameters":{"movement":"down"},"id":8}'
+                data: '{"method":"POST","path":"/device/L4HActuator_abcdef1234567890/action/mvtlinear","parameters":{"movement":"down"},"id":4}'
             - title: Set position (0 to 100)
               message:
                 type: json
-                data: '{"method":"POST","path":"/device/L4HActuator_.../action/openlevel","parameters":{"openLevel":75},"id":24}'
-        docs: Controls a shutter. `movement` accepts "up", "down" or "stop".
+                data: '{"method":"POST","path":"/device/L4HActuator_abcdef1234567890/action/openlevel","parameters":{"openLevel":75},"id":5}'
+        docs: |-
+          Controls a shutter. `movement` accepts "up", "down" or "stop".
+
+          Note: every WebSocket request on a given connection must use a unique,
+          monotonically increasing `id`. The values shown here are illustrative;
+          increment them across the session.
 
       - info:
           name: Switch action
           type: websocket
           seq: 6
         websocket:
-          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          url: "{{wsUrl}}?email={{email}}&password={{password}}&serviceName={{serviceName}}"
           message:
             type: json
-            data: '{"method":"POST","path":"/device/L4HActuator_.../action/switch","parameters":{"value":0},"id":12}'
+            data: '{"method":"POST","path":"/device/L4HActuator_abcdef1234567890/action/switch","parameters":{"value":0},"id":6}'
         docs: Switches a light or a plug on or off. `value` accepts 0 (off) or 1 (on).
 
       - info:
@@ -138,5 +171,8 @@ items:
           url: "{{wsUrl}}?sessionToken={{sessionToken}}"
           message:
             type: json
-            data: '{"method":"POST","path":"/session/logout","parameters":{},"id":13}'
-        docs: Closes the session. Only required when connected with a session token.
+            data: '{"method":"POST","path":"/session/logout","parameters":{},"id":7}'
+        docs: |-
+          Closes the session. Only required when connected via the
+          `sessionToken` flow; with the credentials flow, simply close the
+          WebSocket.

--- a/docs/opencollection.yml
+++ b/docs/opencollection.yml
@@ -1,0 +1,142 @@
+opencollection: "1.0.0"
+
+info:
+  name: DIO Chacon WiFi API
+  summary: Connect and control DIO devices (shutters and switches).
+  version: "1.0.0"
+
+config:
+  environments:
+    - name: Production
+      variables:
+        - name: baseUrl
+          value: https://l4hfront-prod.chacon.cloud
+        - name: wsUrl
+          value: wss://l4hfront-prod.chacon.cloud/ws
+        - name: email
+          value: ""
+        - name: sessionToken
+          value: ""
+        - name: password
+          secret: true
+
+bundled: true
+
+items:
+  - info:
+      name: REST
+      type: folder
+      seq: 1
+    items:
+      - info:
+          name: Login
+          type: http
+          seq: 1
+        http:
+          method: POST
+          url: "{{baseUrl}}/api/session/login"
+          headers:
+            - name: Content-Type
+              value: application/json
+          body:
+            type: json
+            data: |-
+              {
+                "email": "{{email}}",
+                "password": "{{password}}",
+                "installationId": "top"
+              }
+        docs: |-
+          HTTP login. The response contains a session token used to open the
+          WebSocket connection. Copy the returned `sessionToken` into the
+          environment variable `sessionToken`.
+
+  - info:
+      name: WebSocket
+      type: folder
+      seq: 2
+    items:
+      - info:
+          name: Connection
+          type: websocket
+          seq: 1
+        websocket:
+          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+        docs: |-
+          Opens the WebSocket connection. Authenticate with a session token from
+          the REST Login, or directly with credentials:
+          `{{wsUrl}}?email={{email}}&password={{password}}&serviceName=opencollection`.
+          On success the server sends `{"name":"connection","action":"success"}`.
+
+      - info:
+          name: Get user
+          type: websocket
+          seq: 2
+        websocket:
+          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          message:
+            type: json
+            data: '{"method":"GET","path":"/user","parameters":{},"id":1}'
+        docs: Retrieves the current user info.
+
+      - info:
+          name: Get devices
+          type: websocket
+          seq: 3
+        websocket:
+          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          message:
+            type: json
+            data: '{"method":"GET","path":"/device","parameters":{},"id":1}'
+        docs: Lists all the devices of the account.
+
+      - info:
+          name: Get device states
+          type: websocket
+          seq: 4
+        websocket:
+          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          message:
+            type: json
+            data: '{"method":"POST","path":"/device/states","parameters":{"devices":["L4HActuator_..."]},"id":22}'
+        docs: Retrieves the state of the given devices.
+
+      - info:
+          name: Shutter action
+          type: websocket
+          seq: 5
+        websocket:
+          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          message:
+            - title: Move up / down / stop
+              selected: true
+              message:
+                type: json
+                data: '{"method":"POST","path":"/device/L4HActuator_.../action/mvtlinear","parameters":{"movement":"down"},"id":8}'
+            - title: Set position (0 to 100)
+              message:
+                type: json
+                data: '{"method":"POST","path":"/device/L4HActuator_.../action/openlevel","parameters":{"openLevel":75},"id":24}'
+        docs: Controls a shutter. `movement` accepts "up", "down" or "stop".
+
+      - info:
+          name: Switch action
+          type: websocket
+          seq: 6
+        websocket:
+          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          message:
+            type: json
+            data: '{"method":"POST","path":"/device/L4HActuator_.../action/switch","parameters":{"value":0},"id":12}'
+        docs: Switches a light or a plug on or off. `value` accepts 0 (off) or 1 (on).
+
+      - info:
+          name: Logout
+          type: websocket
+          seq: 7
+        websocket:
+          url: "{{wsUrl}}?sessionToken={{sessionToken}}"
+          message:
+            type: json
+            data: '{"method":"POST","path":"/session/logout","parameters":{},"id":13}'
+        docs: Closes the session. Only required when connected with a session token.


### PR DESCRIPTION
Document the Chacon cloud protocol with two machine-readable files under docs/:
- asyncapi.yaml: AsyncAPI 3.0.0 description of the WebSocket protocol (requests, replies and server-pushed device state events).
- opencollection.yml: OpenCollection 1.0.0 executable collection with the REST login and the WebSocket operations, ready to run in an API client.