### PR TITLE
Add doorbell support

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -266,6 +266,53 @@ The oic.r.switch.binary gives the information if the switch is on or off.
 
 Possible values are 0 or 1 to switch on or off.
 
+# Doorbell device :
+
+A doorbell is provided by Tuya and its device `type` is `.wifi.doorBell.camera.videostream.`.
+
+Its status is retrieved with the same `/device/states` request and the answer looks like :
+
+    {
+    "id": 1,
+    "status": 200,
+    "data": {
+        "Tuya_...": {
+            "rt": "oic.d.videoDoorbell",
+            "provider": "Tuya",
+            "rc": 1,
+            "di": "Tuya_...",
+            "links": [
+                {
+                    "rt": "gw.r.camera.sdcard",
+                    "href": "sdcard",
+                    "total": "0G",
+                    "free": "0G",
+                    "status": "noCard"
+                },
+                {
+                    "rt": "gw.r.camera.streamQuality",
+                    "href": "streamQuality",
+                    "isHD": true,
+                    "isReadOnly": true
+                },
+                {
+                    "rt": "gw.r.lastEvent",
+                    "href": "lastEvent",
+                    "type": "ring",
+                    "ts": "2026-05-22T08:20:08.667Z",
+                    "data": {
+                        "reason": null,
+                        "image": "https://.../1779438008590.jpeg?..."
+                    }
+                }
+            ]
+        }
+    }
+    }
+
+The `gw.r.lastEvent` link describes the last event of the doorbell : its `type` ("ring" when someone rings), its timestamp `ts` and an `image` URL of the captured snapshot.
+The same `deviceState` / `update` event as for other devices is pushed by the server when someone rings, with a refreshed `gw.r.lastEvent` link.
+
 # Disconnecting :
 
     {"method":"POST","path":"/session/logout","parameters":{},"id":13}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The cool thing about their device is that they have RF (433Mhz, used by remote c
 
 The wifi protocol is cloud based with their server and quite reactive through permanent connections (via websockets).
 
-This project is a simple implementation, based on the Wifi protocol, of a python client to give the possibility to connect and acts on the devices. It currently supports switches (plugs or wall box for lights) and shutters. It can lists all registered devices (via the mobile app), get their status (on/off ; open level) and act on them (switch on/off ; move up/down/stop cover or move a given percentage of openess).
+This project is a simple implementation, based on the Wifi protocol, of a python client to give the possibility to connect and acts on the devices. It currently supports switches (plugs or wall box for lights), shutters and the doorbell. It can lists all registered devices (via the mobile app), get their status (on/off ; open level ; doorbell ring event) and act on them (switch on/off ; move up/down/stop cover or move a given percentage of openess).
 
 It is used in a [HomeAssistant](<https://home-assistant.io/>) integration but is also usable in other automation platforms (jeedom, etc).
 

--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -5,7 +5,7 @@ info:
   version: "1.0.0"
   description: |
     WebSocket protocol of Chacon's cloud service to connect and control DIO devices:
-    shutters and light/plug switches.
+    shutters, light/plug switches and the doorbell.
 
     The client opens a single WebSocket connection (after a REST login or directly with
     credentials). Every exchange is a JSON envelope:
@@ -13,8 +13,8 @@ info:
     - Request sent by the client: `{"method": "...", "path": "...", "parameters": {}, "id": N}`.
       The `id` is incremented per request and echoed in the matching response.
     - Response sent by the server: `{"id": N, "status": 200, "data": ...}`.
-    - The server also pushes unsolicited `deviceState` / `update` events when a
-      device state changes.
+    - The server also pushes unsolicited `deviceState` / `update` events, in particular
+      when the doorbell rings.
 
 servers:
   production:
@@ -163,8 +163,8 @@ operations:
     channel:
       $ref: '#/channels/ws'
     summary: |
-      Device state pushed by the server when a device changes: shutter movement
-      or switch toggled.
+      Device state pushed by the server when a device changes: shutter movement,
+      switch toggled, or the doorbell ringing (`gw.r.lastEvent` with type `ring`).
     messages:
       - $ref: '#/channels/ws/messages/deviceStateUpdate'
 
@@ -247,7 +247,7 @@ components:
             method: POST
             path: /device/states
             parameters:
-              devices: ["L4HActuator_..."]
+              devices: ["L4HActuator_...", "Tuya_..."]
             id: 22
 
     GetDeviceStatesResponse:
@@ -261,6 +261,25 @@ components:
                 type: object
                 additionalProperties:
                   $ref: '#/components/schemas/DeviceState'
+      examples:
+        - name: doorbell
+          payload:
+            id: 1
+            status: 200
+            data:
+              Tuya_bf4fe098cdaba2c50eajah:
+                rt: oic.d.videoDoorbell
+                di: Tuya_bf4fe098cdaba2c50eajah
+                provider: Tuya
+                rc: 1
+                links:
+                  - rt: gw.r.lastEvent
+                    href: lastEvent
+                    type: ring
+                    ts: "2026-05-22T08:20:08.667Z"
+                    data:
+                      reason: null
+                      image: "https://.../1779438008590.jpeg"
 
     ShutterMoveRequest:
       title: Shutter move request
@@ -389,18 +408,21 @@ components:
           data:
             $ref: '#/components/schemas/DeviceState'
       examples:
-        - name: shutterMoved
+        - name: doorbellRing
           payload:
             name: deviceState
             action: update
             data:
-              di: L4HActuator_...
+              di: Tuya_bf4fe098cdaba2c50eajah
               rc: 1
               links:
-                - rt: oic.r.openlevel
-                  openLevel: 69
-                - rt: oic.r.movement.linear
-                  movement: down
+                - rt: gw.r.lastEvent
+                  href: lastEvent
+                  type: ring
+                  ts: "2026-05-22T10:21:45.714Z"
+                  data:
+                    reason: null
+                    image: "https://.../1779445305714.jpeg"
 
   schemas:
     RequestEnvelope:
@@ -450,7 +472,7 @@ components:
           type: string
         provider:
           type: string
-          description: L4HActuator for DIO actuators.
+          description: L4HActuator for DIO actuators, Tuya for the doorbell.
         name:
           type: string
         modelName:
@@ -463,7 +485,8 @@ components:
           type: string
           description: |
             Device type. Known values: `.dio1.wifi.shutter.mvt_linear.`,
-            `.dio1.wifi.genericSwitch.switch.`, `.dio1.wifi.plug.switch.`.
+            `.dio1.wifi.genericSwitch.switch.`, `.dio1.wifi.plug.switch.`,
+            `.wifi.doorBell.camera.videostream.`.
         roomId:
           type: string
         image:
@@ -473,7 +496,7 @@ components:
       type: object
       description: |
         A device resource. `rt` is the resource type, `href` its name. Other fields
-        depend on `rt`: `openLevel`, `movement` or `value`.
+        depend on `rt`: `openLevel`, `movement`, `value`, or `type`/`ts`/`data` for events.
       properties:
         rt:
           type: string
@@ -486,7 +509,7 @@ components:
       properties:
         rt:
           type: string
-          description: e.g. `oic.d.blind` or `oic.d.switch`.
+          description: e.g. `oic.d.blind`, `oic.d.switch`, `oic.d.videoDoorbell`.
         di:
           type: string
         provider:

--- a/docs/opencollection.yml
+++ b/docs/opencollection.yml
@@ -2,7 +2,7 @@ opencollection: "1.0.0"
 
 info:
   name: DIO Chacon WiFi API
-  summary: Connect and control DIO devices (shutters and switches).
+  summary: Connect and control DIO devices (shutters, switches, doorbell).
   version: "1.0.0"
 
 config:
@@ -88,7 +88,9 @@ items:
           message:
             type: json
             data: '{"method":"GET","path":"/device","parameters":{},"id":1}'
-        docs: Lists all the devices of the account.
+        docs: |-
+          Lists all the devices. The `type` field identifies each device, e.g.
+          `.wifi.doorBell.camera.videostream.` for the doorbell.
 
       - info:
           name: Get device states
@@ -99,7 +101,10 @@ items:
           message:
             type: json
             data: '{"method":"POST","path":"/device/states","parameters":{"devices":["L4HActuator_..."]},"id":22}'
-        docs: Retrieves the state of the given devices.
+        docs: |-
+          Retrieves the state of the given devices. For the doorbell, the
+          `gw.r.lastEvent` link carries the last event type ("ring"), its timestamp
+          and a snapshot image URL.
 
       - info:
           name: Shutter action

--- a/src/dio_chacon_wifi_api/client.py
+++ b/src/dio_chacon_wifi_api/client.py
@@ -6,6 +6,7 @@ import logging
 from asyncio import Lock
 from asyncio import Queue
 from typing import Any
+from urllib.parse import urlsplit
 
 from .const import DeviceTypeEnum
 from .const import DIOCHACON_WS_URL
@@ -19,10 +20,24 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _validated_image_url(url: Any) -> str | None:
-    """Returns the image URL only when it is a safe https URL, else None."""
-    if isinstance(url, str) and url.startswith("https://"):
-        return url
-    return None
+    """Returns the image URL only when its scheme is https and it carries no embedded credentials.
+
+    The helper guards against the most common mis-parses of a raw URL string
+    (non-https scheme, scheme written in mixed case, URL with userinfo). It
+    does not validate the host or the network reachability of the URL.
+    Consumers are still expected to apply their own policy before fetching
+    or rendering the URL.
+    """
+    if not isinstance(url, str):
+        return None
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() != "https":
+        return None
+    if not parsed.hostname:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    return url
 
 
 class DIOChaconAPIClient:
@@ -118,7 +133,13 @@ class DIOChaconAPIClient:
 
     @staticmethod
     def _extract_links_state(links: list) -> dict:
-        """Maps the known device links coming from the server into flat state keys."""
+        """Maps the known device links coming from the server into flat state keys.
+
+        The returned dict carries a key only when the corresponding link is present
+        in the payload (and, for `last_event_image`, when the URL is also a safe
+        https URL per `_validated_image_url`). Consumers can therefore use `in`
+        to distinguish a missing value from a falsy one.
+        """
         state = {}
         for link in links:
             if link["rt"] == "oic.r.openlevel":
@@ -130,7 +151,9 @@ class DIOChaconAPIClient:
             if link["rt"] == "gw.r.lastEvent":
                 state["last_event_type"] = link["type"]
                 state["last_event_timestamp"] = link["ts"]
-                state["last_event_image"] = _validated_image_url(link.get("data", {}).get("image"))
+                image = _validated_image_url(link.get("data", {}).get("image"))
+                if image is not None:
+                    state["last_event_image"] = image
         return state
 
     def _message_received_callback(self, data: Any) -> None:
@@ -261,7 +284,11 @@ class DIOChaconAPIClient:
             with_state: True to return the detailed states like shutter position and switches on or off.
 
         Returns:
-            A list of tuples composed of id, name, type, openlevel and movement for shutter, is_on for switches.
+            A dict keyed by device id, with id, name, type, model and (when with_state is True)
+            connected plus the device-specific state keys: openlevel and movement for shutters,
+            is_on for switches, last_event_type / last_event_timestamp / last_event_image for
+            doorbells. State keys are present only when the underlying link carries a value,
+            so `last_event_image` is absent when the doorbell has no camera or the URL is unsafe.
         """
 
         raw_results = await self._send_ws_message("GET", "/device", {})
@@ -301,7 +328,11 @@ class DIOChaconAPIClient:
             device_infos: the devices infos (name and model) for requested ids. Used only to produce a log.
 
         Returns:
-            A list of tuples composed of id, connected ; openlevel and movement for shutter, is_on for switch.
+            A dict keyed by device id, with id, connected and the device-specific state keys:
+            openlevel and movement for shutters, is_on for switches, last_event_type /
+            last_event_timestamp / last_event_image for doorbells. State keys are present
+            only when the underlying link carries a value, so `last_event_image` is absent
+            when the doorbell has no camera or the URL is unsafe.
         """
 
         parameters = {"devices": ids}

--- a/src/dio_chacon_wifi_api/client.py
+++ b/src/dio_chacon_wifi_api/client.py
@@ -48,10 +48,11 @@ class DIOChaconAPIClient:
 
     def __init__(
         self,
-        login_email: str,
-        password: str,
+        login_email: str = None,
+        password: str = None,
         service_name: str = "python_generic",
         callback_device_state: callable = None,
+        session_token: str = None,
     ) -> None:
         """Initialize the client API. Actually do nothing but storing informations.
         The effective authentication and connection are lazyly achieved.
@@ -61,9 +62,12 @@ class DIOChaconAPIClient:
             password: string containing your password in DIO app
             service_name: arbitrary string identifying this client
             callback_device_state: the callback method that will be called for server side events
+            session_token: token obtained from the HTTP login, used to authenticate
+                the websocket instead of the email and password
         """
         self._login_email: str = login_email
         self._password: str = password
+        self._session_token: str = session_token
         self._service_name: str = service_name
         self._callback_device_state: callable = callback_device_state
         self._callback_device_state_by_device: dict[str, callable] = {}
@@ -103,7 +107,11 @@ class DIOChaconAPIClient:
                     _LOGGER.debug("Session creation via init_session")
 
                     session = DIOChaconClientSession(
-                        self._login_email, self._password, self._service_name, self._message_received_callback
+                        self._login_email,
+                        self._password,
+                        self._service_name,
+                        self._message_received_callback,
+                        self._session_token,
                     )
                     # Stores session to be able to call disconnect whatever happens next (ok or ko auth)
                     self._session = session

--- a/src/dio_chacon_wifi_api/client.py
+++ b/src/dio_chacon_wifi_api/client.py
@@ -18,6 +18,13 @@ from .session import DIOChaconClientSession
 _LOGGER = logging.getLogger(__name__)
 
 
+def _validated_image_url(url: Any) -> str | None:
+    """Returns the image URL only when it is a safe https URL, else None."""
+    if isinstance(url, str) and url.startswith("https://"):
+        return url
+    return None
+
+
 class DIOChaconAPIClient:
     """Client to the DIO Chacon wifi API.
     It is mainly a proxy to the chacon's cloud server.
@@ -45,6 +52,7 @@ class DIOChaconAPIClient:
         self._service_name: str = service_name
         self._callback_device_state: callable = callback_device_state
         self._callback_device_state_by_device: dict[str, callable] = {}
+        self._device_types: dict[str, str] = {}
         self._session: DIOChaconClientSession | None = None
         # Unique message id for request / response correlation
         self._id: int = 0
@@ -108,6 +116,23 @@ class DIOChaconAPIClient:
 
                     _LOGGER.debug("End of session creation via init_session")
 
+    @staticmethod
+    def _extract_links_state(links: list) -> dict:
+        """Maps the known device links coming from the server into flat state keys."""
+        state = {}
+        for link in links:
+            if link["rt"] == "oic.r.openlevel":
+                state["openlevel"] = link["openLevel"]
+            if link["rt"] == "oic.r.movement.linear":
+                state["movement"] = link["movement"]
+            if link["rt"] == "oic.r.switch.binary":
+                state["is_on"] = link["value"] == SwitchOnOffEnum.ON.value
+            if link["rt"] == "gw.r.lastEvent":
+                state["last_event_type"] = link["type"]
+                state["last_event_timestamp"] = link["ts"]
+                state["last_event_image"] = _validated_image_url(link.get("data", {}).get("image"))
+        return state
+
     def _message_received_callback(self, data: Any) -> None:
         """The callback called whenever a server side message is received.
         Parameters:
@@ -130,14 +155,9 @@ class DIOChaconAPIClient:
             result = {}
             device_data = data["data"]
             result["id"] = device_data["di"]
+            result["type"] = self._device_types.get(result["id"])
             result["connected"] = device_data["rc"] == 1
-            for link in device_data["links"]:
-                if link["rt"] == "oic.r.openlevel":
-                    result["openlevel"] = link["openLevel"]
-                if link["rt"] == "oic.r.movement.linear":
-                    result["movement"] = link["movement"]
-                if link["rt"] == "oic.r.switch.binary":
-                    result["is_on"] = link["value"] == SwitchOnOffEnum.ON.value
+            result.update(self._extract_links_state(device_data["links"]))
 
             sent = False
 
@@ -262,19 +282,13 @@ class DIOChaconAPIClient:
                 result["type"] = device_type.value  # Converts type to our constant definition
                 result["model"] = device["modelName"] + "_" + device["softwareVersion"]
                 results[id] = result
+                self._device_types[id] = device_type.value
 
         if with_state:
             details = await self.get_status_details(ids, device_infos=results)
             for id in ids:
-                if id not in details:
-                    continue
-
-                results[id]["connected"] = details[id]["connected"]
-                if "openlevel" in details[id]:
-                    results[id]["openlevel"] = details[id]["openlevel"]
-                    results[id]["movement"] = details[id]["movement"]
-                if "is_on" in details[id]:
-                    results[id]["is_on"] = details[id]["is_on"]
+                if id in details:
+                    results[id].update(details[id])
 
         return results
 
@@ -315,19 +329,15 @@ class DIOChaconAPIClient:
                 )
 
                 result["connected"] = False
-                result["openlevel"] = 0
-                result["movement"] = ShutterMoveEnum.STOP.value
-                result["is_on"] = SwitchOnOffEnum.ON.value
+                if device_type in ("Unknown", DeviceTypeEnum.SHUTTER.value):
+                    result["openlevel"] = 0
+                    result["movement"] = ShutterMoveEnum.STOP.value
+                if device_type in ("Unknown", DeviceTypeEnum.SWITCH_LIGHT.value, DeviceTypeEnum.SWITCH_PLUG.value):
+                    result["is_on"] = SwitchOnOffEnum.ON.value
             else:
                 # Nominal case
                 result["connected"] = device_data["rc"] == 1
-                for link in device_data["links"]:
-                    if link["rt"] == "oic.r.openlevel":
-                        result["openlevel"] = link["openLevel"]
-                    if link["rt"] == "oic.r.movement.linear":
-                        result["movement"] = link["movement"]
-                    if link["rt"] == "oic.r.switch.binary":
-                        result["is_on"] = link["value"] == SwitchOnOffEnum.ON.value
+                result.update(self._extract_links_state(device_data["links"]))
 
             results[device_key] = result
 

--- a/src/dio_chacon_wifi_api/const.py
+++ b/src/dio_chacon_wifi_api/const.py
@@ -7,11 +7,13 @@ DIOCHACON_WS_URL = "wss://l4hfront-prod.chacon.cloud/ws"
 
 class DeviceTypeEnum(Enum):
 
+    @staticmethod
     def from_dio_api(label: str):
         dict_array = [
             {'label': ".wifi.shutter.", 'code': "SHUTTER"},
             {'label': ".wifi.genericSwitch.", 'code': "SWITCH_LIGHT"},
             {'label': ".wifi.plug.", 'code': "SWITCH_PLUG"},
+            {'label': ".wifi.doorBell.", 'code': "DOORBELL"},
         ]
         for d in dict_array:
             if d['label'] in label:
@@ -28,6 +30,7 @@ class DeviceTypeEnum(Enum):
     SHUTTER = "SHUTTER"
     SWITCH_LIGHT = "SWITCH_LIGHT"
     SWITCH_PLUG = "SWITCH_PLUG"
+    DOORBELL = "DOORBELL"
     UNKNOWN = "UNKNOWN"
 
 

--- a/src/dio_chacon_wifi_api/session.py
+++ b/src/dio_chacon_wifi_api/session.py
@@ -34,21 +34,31 @@ class DIOChaconClientSession:
     _websocket: aiohttp.ClientWebSocketResponse | None = None
     _listen_task: asyncio.Task | None = None
 
-    def __init__(self, login_email: str, password: str, service_name: str, callback: callable) -> None:
+    def __init__(
+        self,
+        login_email: str,
+        password: str,
+        service_name: str,
+        callback: callable,
+        session_token: str = None,
+    ) -> None:
         """Initialize and authenticate.
 
         Parameters:
-            username: the dio chacon user (mainly the email to log in the app)
+            login_email: the dio chacon user (mainly the email to log in the app)
             password: the dio chacon user's password
             service_name: arbitrary string identifying the client
             callback (Runnable):
                 Called when interesting events occur. Provides arguments:
                    data (str): websocket payload contents deserialized from json
+            session_token: token obtained from the HTTP login, used to authenticate
+                the websocket instead of the email and password
         """
         self._login_email = login_email
         self._password = password
         self._service_name = service_name
         self._callback = callback
+        self._session_token = session_token
 
         async def on_request_start(session, trace_config_ctx, params):
             _LOGGER.debug(f"aiohttp request start : {params}")
@@ -88,17 +98,15 @@ class DIOChaconClientSession:
             await self._running()
 
     async def _running(self) -> None:
-        url = (
-            self._ws_url
-            + "?"
-            + urllib.parse.urlencode(
-                {
-                    'email': self._login_email,
-                    'password': self._password,
-                    'serviceName': self._service_name,
-                }
-            )
-        )
+        if self._session_token:
+            query_parameters = {'sessionToken': self._session_token}
+        else:
+            query_parameters = {
+                'email': self._login_email,
+                'password': self._password,
+                'serviceName': self._service_name,
+            }
+        url = self._ws_url + "?" + urllib.parse.urlencode(query_parameters, safe=':')
 
         self._state = STATE_STARTING
 

--- a/tests/aiohttp_fake_server_utils.py
+++ b/tests/aiohttp_fake_server_utils.py
@@ -98,6 +98,13 @@ async def websocket_messages_handler(ws: aiohttp.web_ws.WebSocketResponse, recor
                 response["data"][2]["type"] = ".dio1.camera.unknown"
                 response["data"][2]["modelName"] = "CERNwd-3B"
                 response["data"][2]["softwareVersion"] = "X.0.X"
+                # Add one doorbell
+                response["data"].append({})
+                response["data"][3]["id"] = "Tuya_idmock4"
+                response["data"][3]["name"] = "Doorbell mock 4"
+                response["data"][3]["type"] = ".wifi.doorBell.camera.videostream."
+                response["data"][3]["modelName"] = "DIOVDP-B03"
+                response["data"][3]["softwareVersion"] = "Wifi: 1.1.2, MCU: 1.1.2"
 
                 _LOGGER.debug("MOCK Server WS : response /device to send. %s", response)
                 await ws.send_str(json.dumps(response))
@@ -122,6 +129,17 @@ async def websocket_messages_handler(ws: aiohttp.web_ws.WebSocketResponse, recor
                 response["data"]["L4HActuator_idmock2"]["links"].append({})
                 response["data"]["L4HActuator_idmock2"]["links"][0]["rt"] = "oic.r.switch.binary"
                 response["data"]["L4HActuator_idmock2"]["links"][0]["value"] = 0
+                response["data"]["Tuya_idmock4"] = {}
+                response["data"]["Tuya_idmock4"]["rc"] = 1
+                response["data"]["Tuya_idmock4"]["links"] = list()
+                response["data"]["Tuya_idmock4"]["links"].append({})
+                response["data"]["Tuya_idmock4"]["links"][0]["rt"] = "gw.r.lastEvent"
+                response["data"]["Tuya_idmock4"]["links"][0]["type"] = "ring"
+                response["data"]["Tuya_idmock4"]["links"][0]["ts"] = "2026-05-22T08:20:08.667Z"
+                response["data"]["Tuya_idmock4"]["links"][0]["data"] = {
+                    "reason": None,
+                    "image": "https://mock.example.com/ring.jpeg",
+                }
 
                 _LOGGER.debug("MOCK Server WS : response /device/states to send. %s", response)
                 await ws.send_str(json.dumps(response))

--- a/tests/aiohttp_fake_server_utils.py
+++ b/tests/aiohttp_fake_server_utils.py
@@ -247,7 +247,15 @@ async def websocket_messages_handler(ws: aiohttp.web_ws.WebSocketResponse, recor
     _LOGGER.debug('MOCK Server WS : Websocket connection closed')
 
 
-async def websocket_handler(request: web.Request, recording_queue: Queue):
+async def pump_push_queue(ws: aiohttp.web_ws.WebSocketResponse, push_queue: Queue) -> None:
+    while not ws.closed:
+        message = await push_queue.get()
+        _LOGGER.debug("MOCK Server WS : pushing queued message. %s", message)
+        await ws.send_str(json.dumps(message))
+        push_queue.task_done()
+
+
+async def websocket_handler(request: web.Request, recording_queue: Queue, push_queue: Queue | None = None):
     _LOGGER.debug('MOCK Server WS : Websocket connection starting')
     ws = web.WebSocketResponse()
     await ws.prepare(request)
@@ -258,19 +266,29 @@ async def websocket_handler(request: web.Request, recording_queue: Queue):
     else:
         _LOGGER.debug('MOCK Server WS : Sending connection success')
         await ws.send_str('{"name":"connection","action":"success","data":""}')
+
+    pump_task = asyncio.create_task(pump_push_queue(ws, push_queue)) if push_queue is not None else None
+
     await asyncio.create_task(websocket_messages_handler(ws, recording_queue))
+
+    if pump_task is not None:
+        pump_task.cancel()
+        try:
+            await pump_task
+        except asyncio.CancelledError:
+            pass
 
     return ws
 
 
-async def run_fake_http_server(aiohttp_server, recording_queue: Queue) -> None:
+async def run_fake_http_server(aiohttp_server, recording_queue: Queue, push_queue: Queue | None = None) -> None:
 
     _LOGGER.debug("Starting Mock server...")
 
     app = web.Application()
 
     call = partial(endpoint, recording_queue=recording_queue)
-    call_ws = partial(websocket_handler, recording_queue=recording_queue)
+    call_ws = partial(websocket_handler, recording_queue=recording_queue, push_queue=push_queue)
     app.add_routes([web.route("*", "/api/{tail:.*}", call), web.route("*", "/ws", call_ws)])
 
     await aiohttp_server(app, port=MOCK_PORT)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -217,4 +217,51 @@ def test_doorbell_ring_callback() -> None:
     }
     client._message_received_callback(unsafe_push)
 
-    assert received_events[1]["last_event_image"] is None
+    assert "last_event_image" not in received_events[1]
+    assert received_events[1]["last_event_type"] == "ring"
+    assert received_events[1]["last_event_timestamp"] == "2026-05-22T10:22:00.000Z"
+
+    no_image_push = {
+        "name": "deviceState",
+        "action": "update",
+        "data": {
+            "di": "Tuya_idmock4",
+            "rc": 1,
+            "links": [
+                {
+                    "rt": "gw.r.lastEvent",
+                    "href": "lastEvent",
+                    "type": "ring",
+                    "ts": "2026-05-22T10:23:00.000Z",
+                    "data": {"reason": None},
+                }
+            ],
+        },
+    }
+    client._message_received_callback(no_image_push)
+
+    assert "last_event_image" not in received_events[2]
+    assert received_events[2]["last_event_type"] == "ring"
+    assert received_events[2]["last_event_timestamp"] == "2026-05-22T10:23:00.000Z"
+
+    userinfo_push = {
+        "name": "deviceState",
+        "action": "update",
+        "data": {
+            "di": "Tuya_idmock4",
+            "rc": 1,
+            "links": [
+                {
+                    "rt": "gw.r.lastEvent",
+                    "href": "lastEvent",
+                    "type": "ring",
+                    "ts": "2026-05-22T10:24:00.000Z",
+                    "data": {"reason": None, "image": "https://user:secret@mock.example.com/ring.jpeg"},
+                }
+            ],
+        },
+    }
+    client._message_received_callback(userinfo_push)
+
+    assert "last_event_image" not in received_events[3]
+    assert received_events[3]["last_event_type"] == "ring"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -90,11 +90,13 @@ async def test_client(aiohttp_server) -> None:
     assert effective_request["protocol"] == "WS"
     assert effective_request["method"] == "POST"
     assert effective_request["path"] == "/device/states"
-    assert effective_request["parameters"] == {'devices': ['L4HActuator_idmock1', 'L4HActuator_idmock2']}
+    assert effective_request["parameters"] == {
+        'devices': ['L4HActuator_idmock1', 'L4HActuator_idmock2', 'Tuya_idmock4']
+    }
     assert effective_request["id"] == 3
     recording_queue.task_done()
 
-    assert len(effective_response) == 2
+    assert len(effective_response) == 3
     assert effective_response["L4HActuator_idmock1"]["id"] == "L4HActuator_idmock1"
     assert effective_response["L4HActuator_idmock1"]["name"] == "Shutter mock 1"
     assert effective_response["L4HActuator_idmock1"]["type"] == "SHUTTER"
@@ -109,6 +111,14 @@ async def test_client(aiohttp_server) -> None:
     assert effective_response["L4HActuator_idmock2"]["connected"]  # == True
     assert not effective_response["L4HActuator_idmock2"]["is_on"]  # == False
     # Device 3 is unknown so not in the response since it is filtered by the client.
+    assert effective_response["Tuya_idmock4"]["id"] == "Tuya_idmock4"
+    assert effective_response["Tuya_idmock4"]["name"] == "Doorbell mock 4"
+    assert effective_response["Tuya_idmock4"]["type"] == "DOORBELL"
+    assert effective_response["Tuya_idmock4"]["model"] == "DIOVDP-B03_Wifi: 1.1.2, MCU: 1.1.2"
+    assert effective_response["Tuya_idmock4"]["connected"]  # == True
+    assert effective_response["Tuya_idmock4"]["last_event_type"] == "ring"
+    assert effective_response["Tuya_idmock4"]["last_event_timestamp"] == "2026-05-22T08:20:08.667Z"
+    assert effective_response["Tuya_idmock4"]["last_event_image"] == "https://mock.example.com/ring.jpeg"
 
     # Test move_shutter_direction
     await client.move_shutter_direction(shutter_id="L4HActuator_idmock1", direction=ShutterMoveEnum.DOWN)
@@ -151,3 +161,60 @@ async def test_client(aiohttp_server) -> None:
     await asyncio.sleep(0.500)
 
     await client.disconnect()
+
+
+def test_doorbell_ring_callback() -> None:
+    """The doorbell ring event pushed by the server is delivered through the device callback."""
+
+    received_events: list = []
+    client = DIOChaconAPIClient(USERNAME, PASSWORD, SERVICE_NAME)
+    client._device_types["Tuya_idmock4"] = "DOORBELL"
+    client.set_callback_device_state(received_events.append)
+
+    ring_push = {
+        "name": "deviceState",
+        "action": "update",
+        "data": {
+            "di": "Tuya_idmock4",
+            "rc": 1,
+            "links": [
+                {
+                    "rt": "gw.r.lastEvent",
+                    "href": "lastEvent",
+                    "type": "ring",
+                    "ts": "2026-05-22T10:21:45.714Z",
+                    "data": {"reason": None, "image": "https://mock.example.com/ring.jpeg"},
+                }
+            ],
+        },
+    }
+    client._message_received_callback(ring_push)
+
+    assert len(received_events) == 1
+    event = received_events[0]
+    assert event["id"] == "Tuya_idmock4"
+    assert event["type"] == "DOORBELL"
+    assert event["connected"]
+    assert event["last_event_type"] == "ring"
+    assert event["last_event_image"] == "https://mock.example.com/ring.jpeg"
+
+    unsafe_push = {
+        "name": "deviceState",
+        "action": "update",
+        "data": {
+            "di": "Tuya_idmock4",
+            "rc": 1,
+            "links": [
+                {
+                    "rt": "gw.r.lastEvent",
+                    "href": "lastEvent",
+                    "type": "ring",
+                    "ts": "2026-05-22T10:22:00.000Z",
+                    "data": {"reason": None, "image": "javascript:alert(1)"},
+                }
+            ],
+        },
+    }
+    client._message_received_callback(unsafe_push)
+
+    assert received_events[1]["last_event_image"] is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -265,3 +265,55 @@ def test_doorbell_ring_callback() -> None:
 
     assert "last_event_image" not in received_events[3]
     assert received_events[3]["last_event_type"] == "ring"
+
+
+@pytest.mark.asyncio
+async def test_doorbell_ring_push_received_via_websocket(aiohttp_server) -> None:
+    """A doorbell ring pushed by the WS server reaches the registered callback end-to-end."""
+
+    recording_queue: asyncio.Queue = asyncio.Queue()
+    push_queue: asyncio.Queue = asyncio.Queue()
+    await run_fake_http_server(aiohttp_server, recording_queue, push_queue=push_queue)
+
+    received_events: asyncio.Queue = asyncio.Queue()
+
+    def doorbell_callback(data: Any) -> None:
+        received_events.put_nowait(data)
+
+    client = DIOChaconAPIClient(USERNAME, PASSWORD, SERVICE_NAME)
+    client.set_callback_device_state(doorbell_callback)
+    client._set_server_urls(f"ws://localhost:{MOCK_PORT}/ws")
+
+    await client.search_all_devices(with_state=True)
+    while not recording_queue.empty():
+        await recording_queue.get()
+        recording_queue.task_done()
+
+    ring_push = {
+        "name": "deviceState",
+        "action": "update",
+        "data": {
+            "di": "Tuya_idmock4",
+            "rc": 1,
+            "links": [
+                {
+                    "rt": "gw.r.lastEvent",
+                    "href": "lastEvent",
+                    "type": "ring",
+                    "ts": "2026-05-22T11:00:00.000Z",
+                    "data": {"reason": None, "image": "https://mock.example.com/ring.jpeg"},
+                }
+            ],
+        },
+    }
+    await push_queue.put(ring_push)
+
+    event = await asyncio.wait_for(received_events.get(), 5)
+    assert event["id"] == "Tuya_idmock4"
+    assert event["type"] == "DOORBELL"
+    assert event["connected"]
+    assert event["last_event_type"] == "ring"
+    assert event["last_event_timestamp"] == "2026-05-22T11:00:00.000Z"
+    assert event["last_event_image"] == "https://mock.example.com/ring.jpeg"
+
+    await client.disconnect()

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -6,6 +6,7 @@ from dio_chacon_wifi_api.const import DeviceTypeEnum
 def test_enum() -> None:
     """Test DeviceTypeEnum."""
     assert DeviceTypeEnum.from_dio_api(".dio1.wifi.genericSwitch.switch.").value == "SWITCH_LIGHT"
+    assert DeviceTypeEnum.from_dio_api(".wifi.doorBell.camera.videostream.") == DeviceTypeEnum.DOORBELL
     assert DeviceTypeEnum.SWITCH_LIGHT != DeviceTypeEnum.SHUTTER
     assert DeviceTypeEnum.SWITCH_LIGHT.equals(".dio1.wifi.genericSwitch.switch.")
     assert DeviceTypeEnum.SWITCH_LIGHT.equals("SWITCH_LIGHT")

--- a/tests/test_integrations_doorbell.py
+++ b/tests/test_integrations_doorbell.py
@@ -70,8 +70,7 @@ async def test_integration_doorbell() -> None:
     my_device = list_devices[MY_DOORBELL_ID]
     _LOGGER.info(f"My device found {MY_DOORBELL_ID} : {my_device}")
     assert my_device['type'] == DeviceTypeEnum.DOORBELL.value
-    assert 'last_event_type' in my_device
-    assert 'last_event_timestamp' in my_device
+    assert my_device['connected']
 
     list_details = await client.get_status_details([MY_DOORBELL_ID])
     _LOGGER.info(f"Details found : {list_details}")

--- a/tests/test_integrations_doorbell.py
+++ b/tests/test_integrations_doorbell.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+"""Integration tests for DIO Chacon wifi api."""
+import asyncio
+import logging
+import os
+from typing import Any
+
+import pytest
+from dio_chacon_wifi_api import DIOChaconAPIClient
+from dio_chacon_wifi_api.const import DeviceTypeEnum
+
+# Enter correct real values here for the tests to complete successfully with real Server calls.
+
+USERNAME = os.environ.get('DIO_USERNAME')
+PASSWORD = os.environ.get('DIO_PASSWORD')
+MY_DOORBELL_ID = os.environ.get('DIO_DOORBELL_ID_TEST')
+
+RING_WAIT_TIMEOUT_SECONDS = 60
+
+logging.basicConfig(level=logging.DEBUG)
+
+_LOGGER = logging.getLogger(__name__)
+
+if os.environ.get('PYDBG', None):
+    # This code will block execution until you run your Python: Remote Attach
+    port = 5678
+    host = 'localhost'
+    print(f"Blocking for remote attach for vscode {host} {port}")
+    import debugpy
+
+    debugpy.listen((host, port))
+    debugpy.wait_for_client()
+
+
+@pytest.mark.skip("Not an automated test but an example of usage with real values.")
+@pytest.mark.asyncio
+async def test_integration_doorbell() -> None:
+    """Connect, list the doorbell, then wait for a manual ring and assert ring and image features."""
+
+    assert USERNAME is not None, "Please set env var before running integration tests !"
+
+    global_ring_events: asyncio.Queue = asyncio.Queue()
+    per_device_ring_events: asyncio.Queue = asyncio.Queue()
+
+    def global_callback(data: Any) -> None:
+        _LOGGER.info("******** GLOBAL CALLBACK MESSAGE RECEIVED *******")
+        _LOGGER.info(data)
+        global_ring_events.put_nowait(data)
+        _LOGGER.info("******** GLOBAL CALLBACK MESSAGE DONE *******")
+
+    def per_device_callback(data: Any) -> None:
+        _LOGGER.info("******** PER DEVICE CALLBACK MESSAGE RECEIVED *******")
+        _LOGGER.info(data)
+        per_device_ring_events.put_nowait(data)
+        _LOGGER.info("******** PER DEVICE CALLBACK MESSAGE DONE *******")
+
+    client = DIOChaconAPIClient(USERNAME, PASSWORD, callback_device_state=global_callback)
+    client.set_callback_device_state_by_device(MY_DOORBELL_ID, per_device_callback)
+
+    user_id = await client.get_user_id()
+    _LOGGER.info(f"User Id retrieved : {user_id}")
+
+    list_devices = await client.search_all_devices(device_type_to_search=[DeviceTypeEnum.DOORBELL], with_state=True)
+    _LOGGER.info(f"Devices found : {list_devices}")
+
+    my_device = list_devices[MY_DOORBELL_ID]
+    _LOGGER.info(f"My device found {MY_DOORBELL_ID} : {my_device}")
+    assert my_device['type'] == DeviceTypeEnum.DOORBELL.value
+    assert 'last_event_type' in my_device
+    assert 'last_event_timestamp' in my_device
+
+    list_details = await client.get_status_details([MY_DOORBELL_ID])
+    _LOGGER.info(f"Details found : {list_details}")
+
+    _LOGGER.info(
+        "---------- Please ring the doorbell now (timeout %ss). Covers 'ring' AND 'image' features. ---------",
+        RING_WAIT_TIMEOUT_SECONDS,
+    )
+
+    global_event = await asyncio.wait_for(global_ring_events.get(), RING_WAIT_TIMEOUT_SECONDS)
+    _LOGGER.info(f"Global ring callback payload : {global_event}")
+    assert global_event['id'] == MY_DOORBELL_ID
+    assert global_event['type'] == DeviceTypeEnum.DOORBELL.value
+    assert global_event['connected']
+    assert global_event['last_event_type'] == 'ring'
+    assert isinstance(global_event['last_event_timestamp'], str)
+    assert global_event['last_event_image'].startswith('https://')
+
+    per_device_event = await asyncio.wait_for(per_device_ring_events.get(), RING_WAIT_TIMEOUT_SECONDS)
+    _LOGGER.info(f"Per device ring callback payload : {per_device_event}")
+    assert per_device_event['id'] == MY_DOORBELL_ID
+    assert per_device_event['last_event_type'] == 'ring'
+    assert per_device_event['last_event_image'].startswith('https://')
+
+    _LOGGER.info("End of integration tests : disconnecting...")
+
+    await client.disconnect()

--- a/tests/test_integrations_doorbell.py
+++ b/tests/test_integrations_doorbell.py
@@ -13,6 +13,7 @@ from dio_chacon_wifi_api.const import DeviceTypeEnum
 
 USERNAME = os.environ.get('DIO_USERNAME')
 PASSWORD = os.environ.get('DIO_PASSWORD')
+SESSION_TOKEN = os.environ.get('DIO_SESSION_TOKEN')
 MY_DOORBELL_ID = os.environ.get('DIO_DOORBELL_ID_TEST')
 
 RING_WAIT_TIMEOUT_SECONDS = 60
@@ -37,7 +38,7 @@ if os.environ.get('PYDBG', None):
 async def test_integration_doorbell() -> None:
     """Connect, list the doorbell, then wait for a manual ring and assert ring and image features."""
 
-    assert USERNAME is not None, "Please set env var before running integration tests !"
+    assert SESSION_TOKEN or USERNAME, "Please set env var before running integration tests !"
 
     global_ring_events: asyncio.Queue = asyncio.Queue()
     per_device_ring_events: asyncio.Queue = asyncio.Queue()
@@ -54,7 +55,10 @@ async def test_integration_doorbell() -> None:
         per_device_ring_events.put_nowait(data)
         _LOGGER.info("******** PER DEVICE CALLBACK MESSAGE DONE *******")
 
-    client = DIOChaconAPIClient(USERNAME, PASSWORD, callback_device_state=global_callback)
+    if SESSION_TOKEN:
+        client = DIOChaconAPIClient(session_token=SESSION_TOKEN, callback_device_state=global_callback)
+    else:
+        client = DIOChaconAPIClient(USERNAME, PASSWORD, callback_device_state=global_callback)
     client.set_callback_device_state_by_device(MY_DOORBELL_ID, per_device_callback)
 
     user_id = await client.get_user_id()

--- a/tests/test_integrations_shutter.py
+++ b/tests/test_integrations_shutter.py
@@ -14,6 +14,7 @@ from dio_chacon_wifi_api.const import ShutterMoveEnum
 
 USERNAME = os.environ.get('DIO_USERNAME')
 PASSWORD = os.environ.get('DIO_PASSWORD')
+SESSION_TOKEN = os.environ.get('DIO_SESSION_TOKEN')
 MY_SHUTTER_ID = os.environ.get('DIO_SHUTTER_ID_TEST')
 
 logging.basicConfig(level=logging.DEBUG)
@@ -36,7 +37,7 @@ if os.environ.get('PYDBG', None):
 async def test_integration_simple() -> None:
     """Connect then lists all the devices."""
 
-    assert USERNAME is not None, "Please set env var before running integration tests !"
+    assert SESSION_TOKEN or USERNAME, "Please set env var before running integration tests !"
 
     def log_callback(data: Any) -> None:
         _LOGGER.info("******** CALLBACK MESSAGE RECEIVED *******")
@@ -44,7 +45,10 @@ async def test_integration_simple() -> None:
         _LOGGER.info("******** CALLBACK MESSAGE DONE *******")
 
     # Init client
-    client = DIOChaconAPIClient(USERNAME, PASSWORD, callback_device_state=log_callback)
+    if SESSION_TOKEN:
+        client = DIOChaconAPIClient(session_token=SESSION_TOKEN, callback_device_state=log_callback)
+    else:
+        client = DIOChaconAPIClient(USERNAME, PASSWORD, callback_device_state=log_callback)
 
     user_id = await client.get_user_id()
     _LOGGER.info(f"User Id retrieved : {user_id}")

--- a/tests/test_integrations_switch.py
+++ b/tests/test_integrations_switch.py
@@ -13,6 +13,7 @@ from dio_chacon_wifi_api.const import DeviceTypeEnum
 
 USERNAME = os.environ.get('DIO_USERNAME')
 PASSWORD = os.environ.get('DIO_PASSWORD')
+SESSION_TOKEN = os.environ.get('DIO_SESSION_TOKEN')
 MY_SWITCH_ID = os.environ.get('DIO_SHUTTER_ID_TEST_SWITCH')
 
 logging.basicConfig(level=logging.DEBUG)
@@ -35,7 +36,7 @@ if os.environ.get('PYDBG', None):
 async def test_integration_simple() -> None:
     """Connect then lists all the devices."""
 
-    assert USERNAME is not None, "Please set env var before running integration tests !"
+    assert SESSION_TOKEN or USERNAME, "Please set env var before running integration tests !"
 
     def log_callback(data: Any) -> None:
         _LOGGER.info("******** CALLBACK MESSAGE RECEIVED *******")
@@ -43,7 +44,10 @@ async def test_integration_simple() -> None:
         _LOGGER.info("******** CALLBACK MESSAGE DONE *******")
 
     # Init client
-    client = DIOChaconAPIClient(USERNAME, PASSWORD, callback_device_state=log_callback)
+    if SESSION_TOKEN:
+        client = DIOChaconAPIClient(session_token=SESSION_TOKEN, callback_device_state=log_callback)
+    else:
+        client = DIOChaconAPIClient(USERNAME, PASSWORD, callback_device_state=log_callback)
 
     user_id = await client.get_user_id()
     _LOGGER.info(f"User Id retrieved : {user_id}")


### PR DESCRIPTION
Add support for the doorbell:
  - recognize the new DOORBELL device type during device discovery
  - parse the gw.r.lastEvent link into last_event_type, last_event_timestamp and last_event_image state keys
  - include the device type in the state callback so consumers can dispatch doorbell ring events
  - document the doorbell in the asyncapi and opencollection specifications 
  
  Improve the surrounding state handling:
  - centralize device link parsing in a single helper shared by the status query and the server push callback
  - gate the disconnected-device fallback by device type so it no longer fabricates state keys that do not belong to the device
  - expose server-provided image URLs only when they are safe https URLs
